### PR TITLE
Rewrite helper::parse_specs to fix error handling

### DIFF
--- a/citydna/src/helper.rs
+++ b/citydna/src/helper.rs
@@ -35,41 +35,46 @@ pub fn read_file(filename: &String) -> String {
 }
 
 
-pub fn parse_specs(contents: &String) -> (usize, usize, usize, usize, f64, f64) { 
-    // TODO: Error handing unwrapping + Expected number of arguments + Expected type and range of arguments
+pub fn parse_specs(contents: &str) -> Result<(usize, usize, usize, usize, f64, f64), String> { 
+    // TODO: Expected number of arguments + Expected type and range of arguments
     let v: Vec<String> = contents.split(',')
                                .map(|val| val.trim().to_string())
                                .collect();
 
-    let debug_level: usize = v[0].parse().unwrap_or_else( |err| {
-        eprintln!("debug_level = {} can't be parsed as integer. \n error: {}\n ", v[0], err);
-        process::exit(1)
-    });
+    if v.len() != 6 {
+        return Err("Unexpected number of specs (must be exactly 6)".to_string());
+    }
 
-    let skip: usize = v[1].parse().unwrap_or_else( |err| {
-        eprintln!("skip = {} can't be parsed as integer. \n error: {}\n ", v[1], err);
-        process::exit(1)
-    });
+    let debug_level: usize = v[0].parse().map_err(|err| {
+        format!("debug_level = {} can't be parsed as integer.\nerror: {}\n", v[0], err)
+    })?;
 
-    let iterations: usize = v[2].parse().unwrap_or_else( |err| {
-        eprintln!("iterations = {} can't be parsed as integer. \n error: {}\n ", v[2], err);
-        process::exit(1)
-    });
+    let skip: usize = v[1].parse().map_err(|err| {
+        format!("skip = {} can't be parsed as integer.\nerror: {}\n", v[1], err)
+    })?;
 
-    let population_size: usize = v[3].parse().unwrap_or_else( |err| {
-        eprintln!("population_size = {} can't be parsed as integer. \n error: {}\n ", v[3], err);
-        process::exit(1)
-    });
+    let iterations: usize = v[2].parse().map_err(|err| {
+        format!("iterations = {} can't be parsed as integer.\nerror: {}\n", v[2], err)
+    })?;
 
-    let crossover_probability: f64 = v[4].parse().unwrap_or_else( |err| {
-        eprintln!("crossover_probability = {} can't be parsed as a float. \n error: {}\n ", v[4], err);
-        process::exit(1)
-    });
+    let population_size: usize = v[3].parse().map_err(|err| {
+        format!("population_size = {} can't be parsed as integer.\nerror: {}\n", v[3], err)
+    })?;
 
-    let mutation_probability: f64 = v[5].parse().unwrap_or_else( |err| {
-        eprintln!("mutation_probability = {} can't be parsed as integer. \n error: {}\n ", v[5], err);
-        process::exit(1)
-    });
+    let crossover_probability: f64 = v[4].parse().map_err(|err| {
+        format!("crossover_probability = {} can't be parsed as a float.\nerror: {}\n", v[4], err)
+    })?;
 
-    (debug_level, skip, iterations, population_size, crossover_probability, mutation_probability)
+    let mutation_probability: f64 = v[5].parse().map_err(|err| {
+        format!("mutation_probability = {} can't be parsed as a float.\nerror: {}\n", v[5], err)
+    })?;
+
+    Ok((
+        debug_level,
+        skip,
+        iterations,
+        population_size,
+        crossover_probability,
+        mutation_probability
+    ))
 }

--- a/citydna/src/main.rs
+++ b/citydna/src/main.rs
@@ -42,7 +42,10 @@ fn main() {
          iterations, 
          population_size,
          crossover_probability,
-         mutation_probability) = helper::parse_specs(&contents);
+         mutation_probability) = helper::parse_specs(&contents).unwrap_or_else(|err| {
+            eprintln!("{}", err);
+            process::exit(1);
+         });
 
     let contents = helper::read_file(&city_filename);
     let cities: Vec<City> = city::string_to_cities(&contents);


### PR DESCRIPTION
The rewrite makes the following changes:

* Change parameter type from `&String` to `&str`
* Return `Result` type and let caller handle the error
* Return `Err` if there aren't exactly 6 specs
* Fix `mutation_probability` message to mention float, not integer
* Remove spaces around newline character in error messages
